### PR TITLE
尝试解决文件不存在时无法访问导致程序崩溃的问题

### DIFF
--- a/desktop_pet.py
+++ b/desktop_pet.py
@@ -134,12 +134,16 @@ class BuBuAssistant(QWidget):
         self.fontDB = QFontDatabase()
         self.fontID = self.fontDB.addApplicationFont("./font/LanaPixel.ttf")
         self.fontFamily = self.fontDB.applicationFontFamilies(self.fontID)[0]
-        with open('./files/condition.json','r',encoding='utf-8') as f:
-            data = f.read()
-            data = json.loads(data)
-            self.intimacy = data.get('Intimacy')
-            self.health = data.get('Health')
-            self.mood = data.get('Mood')
+        try:
+            with open('./files/condition.json', 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                self.intimacy = data.get('Intimacy', 50)
+                self.health = data.get('Health', 50)
+                self.mood = data.get('Mood', 50)
+        except FileNotFoundError:
+            self.intimacy = 50
+            self.health = 50
+            self.mood = 50
 
     def happybuff(self):
         self.play_times = 1


### PR DESCRIPTION
在文件操作前添加检查或使用 `try-except` 块捕获异常